### PR TITLE
Tournament Admin More Info

### DIFF
--- a/app/features/tournament/routes/to.$id.admin.tsx
+++ b/app/features/tournament/routes/to.$id.admin.tsx
@@ -118,6 +118,8 @@ export default function TournamentAdminPage() {
 					<BracketReset />
 				</>
 			) : null}
+			<Divider smallText>Tournament Information</Divider>
+			<TournamentInformation />
 		</div>
 	);
 }
@@ -415,6 +417,38 @@ function CastTwitchAccounts() {
 			</FormMessage>
 		</fetcher.Form>
 	);
+}
+
+function TournamentInformation() {
+    const tournament = useTournament();
+
+    const teamCount = tournament.ctx.teams.length;
+    const playerCount = tournament.ctx.teams.reduce(
+        (total, team) => total + team.members.length,
+        0,
+    );
+    const checkedInTeams = tournament.ctx.teams.filter(
+        (team) => team.checkIns.length > 0,
+    ).length;
+
+    return (
+        <div className="stack sm">
+            <div>
+                <strong>Tournament details</strong>
+            </div>
+            <div>Tournament ID: {tournament.ctx.id}</div>
+            <div>Event ID: {tournament.ctx.eventId}</div>
+			<div>Ranked Status: {tournament.skillCountsFor}</div>
+            <div>Teams: {teamCount}</div>
+            <div>Players: {playerCount}</div>
+            <div>Checked in teams: {checkedInTeams}</div>
+			
+			<FormMessage type="info">
+				Event ID includes all calender events, this is also the ID used for copying your event.
+			</FormMessage>
+        </div>
+    );
+	
 }
 
 function StaffAdder() {


### PR DESCRIPTION
Adds more info for TO's in the admin panel,

The goal is to make it easier for TO's to be able to copy an event by being able to see the Event ID. because if im not mistaken there is no way to see this value after brackets have started, this also includes player count cause i miss seeing it 🥺. The other info is stated in other places but to have it all in one place is useful to TO's


<img width="917" height="521" alt="Screenshot 2025-07-17 022628" src="https://github.com/user-attachments/assets/9a764f5d-b38d-452f-b419-e93f400eaa9e" />
