### PR TITLE
Add player country info to teams in tourney API

### DIFF
--- a/app/features/api-public/routes/tournament.$id.teams.ts
+++ b/app/features/api-public/routes/tournament.$id.teams.ts
@@ -85,6 +85,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 						"User.discordId",
 						"User.discordAvatar",
 						"User.battlefy",
+						"User.country",
 						"TournamentTeamMember.inGameName",
 						"TournamentTeamMember.isOwner",
 						"TournamentTeamMember.createdAt",
@@ -147,6 +148,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 					avatarUrl: member.discordAvatar
 						? `https://cdn.discordapp.com/avatars/${member.discordId}/${member.discordAvatar}.png`
 						: null,
+					country: member.country,
 					captain: Boolean(member.isOwner),
 					inGameName: member.inGameName,
 					friendCode: friendCodes[member.userId],

--- a/app/features/api-public/schema.ts
+++ b/app/features/api-public/schema.ts
@@ -171,6 +171,10 @@ export type GetTournamentTeamsResponse = Array<{
 		 * @example "https://cdn.discordapp.com/avatars/79237403620945920/6fc41a44b069a0d2152ac06d1e496c6c.png"
 		 */
 		avatarUrl: string | null;
+		/**
+		 * @example "FI"
+		 */
+		country: string | null;
 		captain: boolean;
 		/**
 		 * Splatoon 3 splashtag name & ID. Notice the value returned is the player's set name at the time of the tournament.


### PR DESCRIPTION
Small change to `GET /api/tournament/{tournamentId}/teams` to expose country info. Helps in allowing TOs to pull statistics on which regions are playing in their tournaments as well as useful for pulling information for wikis like Liquipedia or Inkipedia should the community want to focus efforts in it down the line.

I didn't see any tests for the public API so apologies if there's a test I need to edit !!