### PR TITLE
Stronghold Article "Results from Riptide 2025"

### DIFF
--- a/content/articles/results-from-riptide-2025.md
+++ b/content/articles/results-from-riptide-2025.md
@@ -1,0 +1,107 @@
+---
+title: "Results from Riptide 2025"
+date: 2025-09-13
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+Article originally posted at: [https://www.splatoonstronghold.com/news/results-from-riptide-2025](https://www.splatoonstronghold.com/news/results-from-riptide-2025)
+
+# **Results from Riptide 2025**
+
+Riptide 2025 took place between Friday, September 5 and Sunday, September 7\. A memorable event for all who attended, breaking records before taking place\! 2025 marked the first year Splatoon was moved to the main ballroom at the Kalahari Resort in Sandusky, Ohio. With the new location, the Splatoon 3 tournaments were able to share the venue hall with Splatoon Artist Alley and still have plenty of space to spare for crowds to gather around their favorite teams. In addition, Riptide 2025 became the largest North American Splatoon LAN in history with a final count of 481 players, beating Riptide 2024–the previous title-holder–which had a final count of 461\. Full attendance for all of Riptide exceeded 2000 registrants across all games (Splatoon 3, Super Smash Bros. Ultimate and Melee, Rivals of Aether I and II, Mario Kart 8 DX). 
+
+The Splatoon 3 tournament was broken up into seven phases: Group Stage, Bronze Pools, Bronze Bracket, Silver Pools, Silver Bracket, Redemption, and Top 32\. Group Stage took place on Day 1 (Friday); Bronze and Silver Pools and Redemption on Day 2 (Saturday), and Bronze and Silver Bracket and Top 32 on Day 3 (Sunday). 
+
+Riptide also included a Splatoon 3 Collegiate event featuring Swiss and Top 8 stages, crowning their own champion separate from the other Splatoon 3 tournament. 
+
+## **Bronze Bracket**
+
+The Bronze Bracket kicked off with an explosion on Saturday: a specially-scheduled set between Six-Pack Yokes Teal and Six-Pack Yokes Tangerine in the Quarter-Final. This match came with extra spice to wake up its watchers: the losing team had to drink pilk as a consequence\! Pilk, being an unholy combination of Pepsi cola and milk, just what everyone wants to drink right in the morning. 
+
+The set was quite decisive, with a 3-0 victory going to Six-Pack Yokes Teal, leaving their counterpart to move to the back of the ballroom and mix their own pilk before drinking it. Six-Pack Yokes Teal would continue their run through the Bronze Bracket, winning 3-0 over Gear Shift in the Semi-Final, and 3-1 over MILK in the Final, becoming the \#1 team in the bracket. 
+
+## **Silver Bracket**
+
+The Silver Bracket featured a team made up of Riptide commentators (cleverly named “Commentators”), but in a close set in Quarter-Finals, they would go 2-3 to HAMTPHAWKBEAN6-7gor. The latter would make their way to Finals to fight Leviakittens. 
+
+All of the sets in Silver Bracket were tough fights, with no 3-0 scores until the Finals, where Leviakittens shut out HAMTPHAWKBEAN6-7gor in a major upset. Leviakittens (\#57 overall), only seed 60, won soundly against their opponent (\#58 overall) who was seed 43\. 
+
+## **Redemption**
+
+The Redemption event had both a Winners and Losers bracket, made up of six pools. The top three teams of each pool would forge their way into the Top 32 bracket\! The two final teams in Winners Finals would advance to Top 32, along with the winner of the Losers Semi-Final.
+
+Pool K1, the first pool of Redemption, brought teams Wyrmwind, What’s Quackin?, and MatchMyDamage into Top 32\. Pool K2’s top 3 teams were Big Fat Sea Cows, Bossa Nova, and Dead Weight–who would *majorly* outperform their 93rd seed and earn a 9th overall placement at Riptide\! In Pool K3, the teams “Wait I’m The Zonink”, Devils in Disguise, and LYRE (egg woh) SUPER ULTRA DELUXE 4TH ANNIVERSARY EDITION would join Top 32\. Pool K4 sent Hollow Tide, and fan-favorites Triggerfish Zones Supremacy and PSU Blue into Top 32\. 
+
+Pool L1 was special more than most; Winners Finals began with a hype crowd; even the commentators had to note that the noise was befitting of a Sunday night Grand Finals set, at times almost being louder than the commentators themselves. Teams pjackk challenge \+ some and The Yellow Jackets bathed in the crowd’s exuberance and drew in any stragglers looking for a place to put their attention. Pool L1 would be won by pjackk challenge \+ some, going 3-1 over The Yellow Jackets; the 3rd place pool winner was Snom With A Knife. 
+
+Finally, Pool L2 would close out Redemption, adding teams wollnot, HYPE MOMENTS AND AURA, and The Lost and Found to Top 32\. Wollnot took the Losers Bracket and 3rd overall in Pool L2, with HYPE MOMENTS AND AURA at \#2; The Lost and Found at \#1. 
+
+## **Collegiate**
+
+The Splatoon 3 Collegiate event’s Top 8 ran on Sunday, crowning the first Splatoon event champion\! The Finals set was between PSU Blue and USF Gold. PSU Blue would take home their own gold as the 1st place winner in a 3-1 victory over 2nd place USF Gold. Big Fat Sea Cows took 3rd place in the Collegiate event. 
+
+## **Top 32**
+
+The final event for Riptide 2025\. Out of 32 teams, who took home the biggest wins? From upsets, to squidbagging, Rainmaker stalling, and a crowd all-too-willing to let their feelings be known, Top 32 was not lacking in energy. What the commentators thought Grand Finals would sound like from Redemption’s Pool L1 pjackk challenge \+ some vs. The Yellow Jackets match would end up doubled–or even tripled, as Splatoon fans gathered around for one last hurrah for the LAN. 
+
+The top six teams were BEt, Moonlight, Hypernova, FTWin\!, La Vaca, and Voiē Lactee. 
+
+Winners Quarter-Final saw both BEt and Moonlight be sent to the Losers Bracket; La Vaca would take down BEt 3-0. Moonlight, by far no strangers to clashing with Hypernova, would end up 1-3 in a set that had so many spectators crowded around the table that the TOs couldn’t tell which teams were playing. 
+
+Winners Semi-Final witnessed a tough set between FTWin\! and La Vaca, though the former would emerge victorious with a 3-2 victory and send La Vaca to the Losers Bracket. On the other side of the bracket, Hypernova faced Voiē Lactee, but would go 0-3 and enter the Losers Bracket. 
+
+This left the Winners Final between Voiē Lactee and FTWin\!, two teams who, at the time, were tied with a win-loss record of 7-0 at Riptide. FTWin\!, however, would be the team updating their record to 7-1 and being sent to Losers Bracket, following yet another tense close set with a score of 2-3. 
+
+### **Top 32 \- Losers Bracket**
+
+In the Losers Bracket, BEt’s journey through Top 32 would last just a bit longer, seeing them win 3-0 against LYRE in Round 5\. In Round 6, they would go 1-3 to Hypernova and take their exit from the event, tied at 5th place. 
+
+Meanwhile, Moonlight would find themselves in a humorous predicament, as their opponent in Losers Round 5 was Cleanup Crew. Cleanup Crew, a pickup team made up of ori\_, Lux, M4x, and Chara… their coach. This has happened several times in recent tournament history where members of Moonlight had to face their coach; Barnacle Bash \#9 as one example (Dollar Store Dread Comps vs. Clairen is carried). 
+
+Moonlight would win 3-0 against their coach’s team and meet La Vaca in Losers Quarter-Final. The set ended on a painful point for both Moonlight and the crowd, who expressed disapproval at the set point game being on Humpback Pump Track Rainmaker, and that the set ended with not just a Rainmaker stall, but a squidbag from La Vaca to boot. The crowd’s sentiment toward the Rainmaker mode was only a prelude to what was yet to come. Moonlight would go 1-3 in the set and also take 5th place at Riptide, tied with BEt. 
+
+La Vaca would take on Hypernova next in Losers Semi-Final. For the second set in a row, La Vaca marched to a 3-1 victory. The set point would also end up in Rainmaker (this time on Museum d’Alfonsino), but no stall tactics were employed as the match went down to the wire and La Vaca would take the lead right in the final 20 seconds of the game. Hypernova finished in 4th place, one placement higher than their seed \#5; a positive sendoff for Lexi, who has previously stated that Riptide was her last event with Hypernova (for now) as she takes a step back from competitive Splatoon. 
+
+Losers Finals gave La Vaca their shot at redemption against FTWin\!, where the stakes were high to see who would make it to Grand Finals. The first match was Splat Zones at Hagglefish Market. At the very last moment, La Vaca took control of the zone, forcing the match into overtime, and would end up retaking the lead after burning through their penalty points and surpassing FTWin\!, ending the match with an 83-82 score. 
+
+Next, the teams went to Mahi-Mahi Resort for a Splat Zones rematch as FTWin\!’s counterpick. FTWin\! had a strong opening, able to hold the zone until their objective went down into the 50s, but an unfortunate Reefslider into the water just as the water level was dropping saw La Vaca capitalize and take control for the first time. The match would go into overtime again, and La Vaca’s strong hold on the zone saw them get just one point away from matching FTWin\! before sam’s fast inking with that Stickerz Splatana Stamper recapped the zone and gave FTWin\! the win, with a score of 96-95. 
+
+La Vaca would counterpick to Clam Blitz at Museum d’Alfonsino. It would take about a minute and 15 seconds for the first points to be scored, by La Vaca, whose 30-second push from 100 to 36 points remaining gave them a major lead. Throughout the match, FTWin\! seemed to have no problem making plays or building Power Clams, but their real struggle came from actually scoring. Even with overtime padding the match length, La Vaca wasn’t able to make another attempt at the basket, but on the other hand, FTWin\! failed to score even once in the match, leaving La Vaca with a 64-0 victory. 
+
+FTWin\!’s next counterpick would be Tower Control at Hagglefish Market. Thunder’s Crab Tank was a huge pain point for FTWin\!; seemingly always active and putting up an impassable offense for La Vaca. As the clock neared the end of the match, overtime looked likely again as FTWin\! rode the tower to the next checkpoint. At the very last second, while the spectator cam was focused elsewhere, La Vaca was able to slip behind FTWin\! and retake the tower right before overtime was necessary. The final score was 62-48 in La Vaca’s favor, earning them a third-in-a-row set victory 3-1 and advancing to Grand Finals. FTWin\! finished their Riptide run in 3rd place, earning bronze at the ending ceremony. 
+
+### **Top 32 \- Grand Finals**
+
+After waiting for a few hours since their last set, Voiē Lactee finally had Grand Finals on their hands, with a very hungry La Vaca to get through. La Vaca had blazed through some of Splatoon 3’s finest top level teams, and there was just one more on the plate in front of them. 
+
+The set was given a beautiful, poetic introduction narrated by hypercube, channeling the vibe of a fairy tale reading as they recounted the story of Riptide thus far, seeing a record-breaking 481 players compete across three days. To quote hypercube’s story… “Sad may it be, an end is in sight. So for one final time… LET’S\! GET\! HYPE\!” As one may expect, this was met with raucous cheer and clappers in a frenzy. 
+
+Grand Finals began with Splat Zones on Um’ami Ruins. La Vaca took the zone first and employed a ferocious offense that Voiē Lactee couldn’t match. Gos broke into Voiē Lactee’s base and created an opening for the rest of La Vaca to join in. The crowd began chanting “Let’s go Gos\!” as he spearheaded the bullying to keep Voiē Lactee from leaving their spawn. La Vaca’s opening push brought their objective from 100 to just 11 before Voiē Lactee was able to finally put the zone in their favor, with a little over 3 minutes left on the clock. As strong as La Vaca’s initial push was, once Voiē Lactee had the zone, they were able to defend it all the way to a knockout, bringing the set to 1-0. 
+
+La Vaca counterpicked back to Um’ami Ruins (as the crowd booed), this time for Clam Blitz. The game was a stalemate for a while as players skirmished; even rousing back-and-forth chants of “Offense\!” “Defense\!” from the crowd couldn’t goad anyone into committing to score early. It took over three minutes for the first Power Clam to make it into a basket, courtesy of La Vaca, to a great applause from the crowd. 
+
+Following the basket closing was a wipeout on Voiē Lactee, which gave La Vaca a second chance to reopen the basket for another push. By the time they were done, La Vaca’s score had gone from 100 to 45 points, with one minute left in the match. With seven seconds remaining, Voiē Lactee finally got a Power Clam into the basket to add points to their name, but between Gos and Thunder taking out 3/4ths of Voiē Lactee, they weren’t able to out-score La Vaca. The set was now tied 1-1. 
+
+Voiē Lactee chose to take La Vaca to a Tower Control match at Undertow Spillway for match 3\. There was excitement as La Vaca’s Wave pulled out the E-liter 4K Scope for the match, switching off of the Snipewriter 5H. La Vaca, once more, was the first to start gaining points, though the lead was already out of their hands before 45 seconds had passed. As Voiē Lactee continued to the second checkpoint, the crowd once more tried to provoke a bold play with their “Offense\!” “Defense\!” chants, but the most that La Vaca could do was get Voiē Lactee off of the tower momentarily before they flocked back. It was enough to get the match to overtime, where La Vaca was finally able to score again, but they were stopped short after passing the first checkpoint and were now down 1-2 in the set. 
+
+As soon as the counterpick was revealed to be Rainmaker on Scorch Gorge, the crowd erupted into another round of booing, which then turned into an angry chant that we really can’t repeat here. The crowd was at their loudest during this match–rightfully so; this is Grand Finals\!–and once the match officially started, began with their “Offense\!” chants again in favor of La Vaca. They quickly brought the Rainmaker to the first checkpoint in the first 45 seconds of the match. 
+
+With three minutes left in the game, Voiē Lactee managed to assemble and get their first points to the tune of the crowd back at their “Offense\!” “Defense\!” call and response. Right as Voiē Lactee broke through the checkpoint, a big Ultra Stamp flew in and stopped the Rainmaker carrier from taking the lead. The score was 68 (La Vaca) to 69 (Voiē Lactee) with two and a half minutes remaining, and both teams only far enough to pass the first checkpoint. 
+
+The Ultra Stamp stopping the Rainmaker wasn’t enough to crumble Voiē Lactee’s formation, and soon enough, they were able to take the lead in another push, which was stopped… by another Ultra Stamp, courtesy of Xenith, who had been shattering dreams all Riptide with it. However, the damage was done, and with a comfortable enough lead ahead of La Vaca with one minute left, Voiē Lactee took a memo from La Vaca’s match against Moonlight and began the stall game. 
+
+La Vaca wouldn’t be able to recover the Rainmaker while it was in the corner, and the last 40 seconds of the final game of Riptide 2025 was defined by the crowd growing increasingly louder as they chanted more things that we can’t publish in this article. It was very clear to everyone in attendance, however, that the crowd was very displeased that Grand Finals had to end with Rainmaker stall. 
+
+La Vaca ended Riptide 2025 in 2nd place, earning silver at the victory ceremony, and the 1st place would go to Voiē Lactee in a 3-1 set. 
+
+After the cheers went up and petered out, once again, the crowd used their collective voices to let everyone know how much they disliked Rainmaker. This would flood into social media, once again sparking the debate of “Should tournaments be Splat Zones-only”?
+
+As Riptide winds down for the year and everyone travels home, we don’t have much time to wait until the action picks up again, with the Splatoon 3 North American League starting just two weeks after Riptide, on September 19, 2025, with the North American League Show. Players and collaborators have been teasing great content to come for this major event, so while the community won’t be in person while the NA League plays out, we’re certainly in for a treat with the community on stream. 
+
+We’ll look forward to watching\! 
+
+Original Posting Date: September 13, 2025
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add article from Splatoon Stronghold originally posted at https://www.splatoonstronghold.com/news/results-from-riptide-2025