### PR TITLE
Add Stronghold Article "Splatoon 3 NA League Event 2 Preseason Week 2"

### DIFF
--- a/content/articles/splatoon-3-na-league-event-1-preseason-1.md
+++ b/content/articles/splatoon-3-na-league-event-1-preseason-1.md
@@ -1,0 +1,154 @@
+---
+title: "Splatoon 3 North American League Event #2 (Preseason Week 2)"
+date: 2025-09-30
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+Article originally posted at: [https://www.splatoonstronghold.com/news/splatoon-3-north-american-league-event-2-preseason-week-2](https://www.splatoonstronghold.com/news/splatoon-3-north-american-league-event-2-preseason-week-2)
+
+# **Splatoon 3 North American League Event \#2 (Preseason Week 2\)**
+
+Saturday, September 27, 2025 saw the second stream for the Splatoon 3 North American League, the final of two Preseason events. Starting next week, the training wheels come off, and final results will matter towards determining a team’s eligibility for the Splatoon 3 North American League Playoffs in December. Only the five highest scores will count towards that eligibility, so if a team doesn’t perform their best in the first Regular Season event, there will be seven others to aim higher in\! 
+
+## **The League Show Episode 2**
+
+The NA League stream was preceded by the second Splatoon 3 North American League Show episode. This episode was slightly longer than the first episode, close to 30 minutes long. The episode began by recapping the Top 8 bracket from the first Preseason stream and highlighting key players and plays that would make-or-break a match. This segment concluded with showing the current team standings, with Duck Motif in first place with 100 points, and Triggerfish Zones Supremacy (TZS) right behind them in second place, with 95 points. 
+
+The next segment featured a handful of community figures: Cyren, Sapph, Popgun, and Falco. These four were split into groups, consisting of Cyren and Sapph vs. Popgun and Falco, and were faced with guessing a mystery weapon without being able to see what it looked like. The only clue given was what sound the weapon made… provided by the second teammate making that sound with their mouth. It was a silly segment for certain; the mystery weapons were the L-3 Nozzlenose, Tri-Slosher, E-Liter 4K, Glooga Dualies, Bloblobber, Hydra Splatling, Tenta Brella, and Splatana Wiper. An interesting facet of this challenge is that the guesser had to say the full name of the weapon, not just an abbreviation–“E-liter” did not count; the correct answer was “E-liter 4K”. Popgun and Falco won the game, finishing their guessing gauntlet one minute faster than Cyren and Sapph with the same score of 6/8 correct guesses. 
+
+Afterward, Mellana and her team of Nox, Magic, and Vicvillon showed teamwork making the Grizzco dream work in Salmon Run, talking the viewer through an entire Salmon Run shift (minus a visit from any King Salmonids). The Salmon Run segment explained Known Occurrences and tide shifts and showed off how high-level Salmon Runners cooperate to not just survive, but surpass the quota of Golden Eggs. 
+
+Following the Salmon Run showcase, Zach explained the process of how to register for a Sunday Scrim to surprise guest EE, a very well-known commentator in the *Super Smash Bros.* community. One important takeaway from this segment that hasn’t been discussed previously is that participation for the Sunday Scrim is based on a lottery system: signing up isn’t enough; you have to be selected for the chance to participate. Anyone can sign up to play, whether you’re on your own, with a friend, two friends, or a team of four, but actually getting to partake will depend on your luck. 
+
+The League Show concluded with a reminder of the dates for all upcoming events, including the League Show, NA League, Sunday Scrim, and Playoffs. 
+
+## **Top 8 Bracket**
+
+<img width="1536" height="722" alt="nal_p2_ladder" src="https://github.com/user-attachments/assets/03ddf686-fdb1-41db-a44b-ebb4ff83b532" />
+
+
+The Top 8 stream is proving to be a huge turnout around the world–one week after the first Preseason stream, and the video on Nintendo’s YouTube channel already has over 52,000 views. Within an hour of the second Preseason Top 8 stream, the video garnered close to 20,000 views. Compared to last week, the Top 8 stream’s runtime for Preseason Event \#2’s was just over 30 minutes longer than the previous week. 
+
+This week, the Top 8 Bracket featured no returning teams from last week’s Top 8 stream. However, Xiphias, one team who was in last week’s stream came close, reaching 10th in this Preseason event. The top teams this week were: 
+
+1. Hypernova  
+2. FreeFlow  
+3. Chef Lugoli  
+4. N-ZAAP\!  
+5. FOAMS NA  
+6. Rotten Potato  
+7. DPS Mostly  
+8. Refine
+
+Hypernova and FreeFlow are very recognizable top-level teams: both qualified and participated for the prestigious Splat World Series tournament in August 2025\. 
+
+The stream opened up to some new faces; Nine was still present and acting as the host, but Jordan, Zach, and “Big Money” Mellana were not for the first time. Nine was joined by Nox and Rissa, who all explained important dates to look out for, the rules of the tournament, eligible maps and modes, and the first bracket, beginning with Winner’s Quarterfinals, which looked like so: 
+
+- Hypernova vs. Freedom  
+- N-ZAAP\! vs. FOAMS NA  
+- FreeFlow vs. Refine  
+- Chef Lugoli vs. DPS Mostly
+
+N-ZAAP\! vs. FOAMS NA would be the first set of the event, and the hosts shared their thoughts and experience with the teams on display, and the mode and map (the classic Splat Zones on Mako Mart combo) that would be up. Opening up to the first match, we were given credits to Piko, the stream’s spectator camera operator. Thanks for your hard work, Piko\! 
+
+As a reminder, the Splattercolor Screen is legal in this event, and it is featured heavily in this week’s stream, so if you have sensitivity to its visual effects, please take caution while viewing replays. 
+
+### **Winner’s Quarterfinals: N-ZAAP\! vs. FOAMS NA (1-3)**
+
+The first match of the second Splatoon 3 North American League Top 8 Bracket, and what a pulse-pounding game\! Starting on Splat Zones at Mako Mart, the match opened to show an uncommon weapon composition on the side of FOAMS NA, with the Range Blaster, Colorz Aerospray, N-ZAP ‘85, and Order Roller. N-ZAAP\! almost had an early knockout with about a minute and a half left in the match, but FOAMS NA forced their opponent out of the zone to retake it while N-ZAAP\! had just two points left to win. At 30 seconds remaining, N-ZAAP\! would return the favor and steal the zone when FOAMS NA was one point from taking the lead. FOAMS NA had possession of the zone when the game went into overtime, and capitalizing on a numbers advantage led them to their first victory, 99-98\! 
+
+Another classic mode/map combination, Tower Control at Inkblot Art Academy, was the scene for the second match. N-ZAAP\! was fairly dominant the entire match, barely yielding to FOAMS NA until a minute and a half left in the game, where FOAMS NA was able to take the lead and grow a sizable 30-point gap between the scores. At a critical point for N-ZAAP\!, they were able to get a wipeout with 21 seconds remaining to aid their final push of the game. The match would go into overtime, the tower slowly moving towards the lead, and a triple on FOAMS NA would let N-ZAAP\! repay their opponent once again and slide past them in overtime to win the game, 80-79. 
+
+Rainmaker Humpback Pump Track was up next. N-ZAAP\!’s Pezpop\! would be popping the Kraken Royale every time the Rainmaker approached. FOAMS NA’s BOWLING\!\!\! would treat viewers to a spectacle of movement, dodging the Kraken Royale around the pedestal while carrying the Rainmaker. Despite the Kraken Royale’s presence–as solid of a defense as it is–FOAMS NA would win 59-40. The final match in the set would be Turf War at Museum d’Alfonsino. Finally, we would see some significant weapon changes, with N-ZAAP\! pulling out the REEF-LUX 450 and Octobrush Nouveau, and FOAMS NA bringing out a Sploosh-o-matic. In the closest Turf War match yet, the final score would be 45.6% to 44.2%, favoring FOAMS NA, and seeing them advance to Winner’s Semifinals, while N-ZAAP\! would be sent to the Loser’s Bracket. 
+
+### **Winner’s Semifinals: FreeFlow vs. Chef Lugoli (3-2)**
+
+To quote Nine following the end of Winner’s Quarterfinals, “We watched the only 3-1 set, folks”. The other sets all ended in a score of 3-0, with Hypernova vs. FOAMS NA and FreeFlow vs. Chef Lugoli being the two sets of the Semifinals. N-ZAAP\!, Rotten Potato, DPS Mostly, and Refine would be facing one another in the Loser’s Bracket. 
+
+The second set would kickoff with Clam Blitz at Museum d’Alfonsino. Before the first minute was up, FreeFlow would have an early 62-100 lead over Chef Lugoli, and held onto this scoreboard until two minutes remaining. In their first push of the game, Chef Lugoli would dunk three Power Clams into the basket and abruptly steal the lead from FreeFlow. FreeFlow would get a wipeout on Chef Lugoli, but with the score now 40-62 favoring Chef Lugoli, the damage was done. It was now on FreeFlow to make a clutch play, and did they deliver in the final 30 seconds, by stealing the lead with a single clam thrown into the basket in the very last tick it remained open\! FreeFlow’s Len., a shark in the chaotic waters of overtime, got a triple on Chef Lugoli and circled their dropped Power Clam as the seconds ticked down to FreeFlow’s 63-60 victory. 
+
+Game two… A lot to say about game two\! Tower Control at Hagglefish Market, starting off quite unusually, and only getting weirder from there. FreeFlow, within the first half of the game, got wiped out three times. With two minutes remaining, a major disconnection occurred, where two members of FreeFlow and one member of Chef Lugoli DC’d. Despite the NA League’s rulebook stating that matches could only be replayed if the DC occurred in the first minute of the game, the Tournament Admin waived the rule and the match was replayed. In the runback, it was still clearly evident that several players were experiencing lag during the match, but everyone stayed intact until 15 seconds remained, where the same players disconnected. The match couldn’t be restarted, and now Chef Lugoli had the 3v2 advantage going into overtime. Although they were not in the lead, they caught up quickly thanks to their numbers. Len., however, would toss that “gg special” Booyah Bomb onto the tower to give JJaeigh the opportunity to steal the 2v3 win over Chef Lugoli, 55-52. 
+
+Splat Zones at Crableg Capital–don’t blink or you’ll miss the lead changes in this game, from FreeFlow, to Chef Lugoli, back and forth. Triple Inkstrikes and Booyah Bombs would be the stars in retaking and holding the zone. Chef Lugoli, holding strong onto a lead with 22 points to go, would stop FreeFlow, at 23 points remaining, from passing their score with a clutch zone flip. FreeFlow wouldn’t advance further in the match, and Chef Lugoli would win their first game of the set in a knockout. Chef Lugoli would run into game four–Rainmaker at Inkblot Art Academy–with full steam after their victory, and give FreeFlow a tough climb. If an early push to 25 wasn’t enough for FreeFlow to worry about their opponent having, it would quickly worsen as Makoto snuck behind enemy lines after they left the Rainmaker unattended, bringing Chef Lugoli’s lead to 18 remaining. Twelve seconds left in the match, and Chef Lugoli would secure a wipeout over FreeFlow and once again win, with a match score of 82-45. Onto game five\! 
+
+Trust a Turf War match to shake up a team’s weapon composition–every member of FreeFlow swapped to something new, accommodating a new heavily-painting main weapon in the REEF-LUX 450 MIL-K. Chef Lugoli would see two new weapon swaps, to a Splash-o-matic, and Bamboozler 14 Mk II, which REDRUM was well-renowned for in the past. While the lead at Urchin Underpass was shaky for both teams, JJaeigh would tunnel-vision on one goal: getting into the enemy base and causing as much havoc as possible. Multiple times, JJaeigh had snuck across the map and painted Chef Lugoli’s spawn yellow, forcing them to waste precious time painting over it. This would be instrumental in FreeFlow securing the final win of the set, 54.2% to 39.0%\! 
+
+### **Winner’s Finals: Hypernova vs. FreeFlow (2-3)**
+
+Hypernova would win 3-0 over FOAMS NA to meet FreeFlow in the Winner’s Finals. In the Loser’s Bracket, Chef Lugoli would be facing N-ZAAP\! and FOAMS NA would be seeing Refine. The two titans of this week’s Top 8, Hypernova and FreeFlow, would be an interesting set, with Hypernova fielding two relatively new additions (Captain Happy and Fishy), and FreeFlow’s “you never know what they’re going to pull out” playstyle wanting to favor the recently-buffed Sorella Brella.  
+
+To start, the game would take place on Splat Zones at Undertow Spillway. Things would initially look bad for Hypernova as FreeFlow cruised their way from 100 to 37 points on their scoreboard within the first minute of the game. The next three and a half minutes would see Hypernova slowly warm up and get the ground beneath their feet–with 30 seconds remaining, they would take the lead from FreeFlow for the first time, and not done yet, would even take the knockout victory with just five seconds on the clock. 
+
+For the second time in a row, Turf War at Urchin Underpass was chosen. Immediately, FreeFlow would get a triple on Hypernova, giving Len. and JJaeigh free reign to start living in Hypernova’s walls and covering the flank routes. JJaeigh, whose sole goal in Turf War seemed to be sneaking into the enemy spawn to cause as much disaster as possible, was on Hypernova’s side of the map more than FreeFlow’s. With less than one minute remaining, those distraction tactics would see all four members of Hypernova dogpiling to take out JJaeigh. This would lead to Hypernova finally pushing past the midpoint of the map to take the lead, snowballing into a triple on FreeFlow in the final 20 seconds of the game, and a Hypernova win, 50.7% to 44.4%. 
+
+Clam Blitz at Um’ami Ruins, a third match in a row where Hypernova began on the wrong foot. Between going down three players in the first 30 seconds, to being down 100 \- 41 by the end of the first minute, it was only a matter of time before Hypernova couldn’t recover from their opening struggles. Although they did manage one push to get close to FreeFlow’s score, with 11 seconds remaining, FreeFlow ended the game in a knockout victory for themselves and gave Hypernova their first game loss in the Top 8\. 
+
+Game four (Tower Control at Inkblot Art Academy) can be summed up with two quotes from the hosts: 
+
+1. “I mean, FreeFlow, honestly, kind of needs to force a miracle \[...\]” (Nox)  
+2. “One of the most miraculous games of Splatoon I’ve EVER seen\!” (Nine)
+
+Hypernova began game four with the opening they’ve needed this entire set, managing to get through the second checkpoint in under one minute; their opening push ended with them needing 26 points to win. They would push the tower as far as 12 points to win, which sounded like it should have been a safe lead. However, in Splatoon, there is no such thing as a “safe lead”. Going into the final seconds of the match, FreeFlow had possession of the tower, which was halfway into their own spawn, and they needed to bring it across the entire map without Hypernova touching it once. 
+
+And they did it. 
+
+In overtime, JJaeigh and Cakes started on the tower, with Len. and Adapt regrouping to refresh with the Tacticooler. A Splattercolor Screen was tossed, blocking Hypernova’s view from their platform while the tower crossed the grates area. Hypernova brought out a Crab Tank, which was quickly neutralized by a Booyah Bomb. Hypernova threw Triple Inkstrikes at the tower after the second checkpoint was cleared, but no one was close enough to claim the tower while FreeFlow retreated. A Booyah Bomb took out three members of FreeFlow, and HENLO–one of two members left active on Hypernova’s side–hopped on the tower to fight JJaeigh for control. 
+
+Just 9 more points for FreeFlow to retake the lead in overtime. 
+
+JJaeigh took out HENLO, but Fishy quickly replaced HENLO to contest JJaeigh, Sorella Brella vs. Heavy Edit Splatling. Fishy went down, and Cakes joined JJaeigh on the tower. The tower sat long enough at the third checkpoint for FreeFlow to claim a hard, well-played victory over Hypernova, after nearly one minute of overtime\! With that victory, the set was tied 2-2, and it was time for another game five\! 
+
+The final pick was to Rainmaker at Museum d’Alfonsino. FreeFlow already broke through the first checkpoint 30 seconds into the game, and pushed further to 27 points to go to knock out by the end of the first minute. A double splat enabled Hypernova to get their first checkpoint not too long afterward. Captain Happy tried to take a leap off the top grates of FreeFlow’s spinner, but got caught by the tail end of a Booyah Bomb, leaving the Rainmaker on the spinner grates, and Hypernova’s push just shy of the lead, 34-27, with two minutes to go. FreeFlow held their lead steady, splatting Hypernova’s Rainmaker carrier right as the final second ticked down, earning them a win 73-66, a reverse-sweep upset over seed \#1, and a spot in the Grand Finals set\! After two rigorous game five sets, FreeFlow deserved their break. 
+
+### **Loser’s Semifinals: Chef Lugoli vs. FOAMS NA (3-1)**
+
+Chef Lugoli and FOAMS NA both won over their Loser’s Quarterfinals opponents 3-1, and would now be seeing one another in the Semifinals to determine who would face Hypernova up next. Chef Lugoli would see a player substitute, with Creed Edit (Splatana player) being replaced by Ballóòn (N-ZAP player). 
+
+Starting on Tower Control at Mako Mart, FOAMS NA, with their unconventional double blaster (S-BLAST ‘91 and Range Blaster) \+ Colorz Aerospray \+ N-ZAP ‘85 composition, would take the immediate advantage by getting a wipeout over Chef Lugoli. Aside from their weapon composition, they would also deploy stall tactics, hurling bomb after bomb at the tower while it tried to pass by that raised platform in the enemy’s spawn. As unorthodox as FOAMS NA’s game was, it proved effective in earning them a 70-65 win for the first match of Loser’s Semifinals. 
+
+Game two was a Turf War at Um’ami Ruins. Unsurprisingly, both teams brought out a Splash-o-matic, with Chef Lugoli bolstering their inking power by adding a REEF-LUX 450 to the roster. It was anyone’s game for the first two minutes; even going into the final minute, there was no clear lead. As the game closed, players were scattered across the map and in one another’s spawn. Judd’s verdict was 46.4% to 43.9%, to Chef Lugoli\! Into game three, Chef Lugoli continued their win streak. It was their game from the first minute, where they got the first checkpoint, when they wiped out FOAMS NA with three and a half minutes on the clock, and when they knocked out their opponent for the win just 30 seconds later. There was a tense moment when they took the Rainmaker up the precarious left side; the carrier tried to squid roll behind the last checkpoint but instead got splatted by the Splattercolor Screen, but teamwork made their dream work\! 
+
+The final match of the Loser’s Semifinals was Splat Zones at Urchin Underpass. The first minute went quite neutrally, with both teams making small headway toward their objective. FOAMS NA would be the first to break away and climb ahead, but a critical triple from Ori\_ gave Chef Lugoli control of the zone. They held the zone through a small handful of penalty points, and drove their score down to zero, even getting a last-second wipeout over FOAMS NA before the knockout win was declared. Chef Lugoli would now go and face Hypernova in the Loser’s Finals. 
+
+### **Loser’s Finals: Hypernova vs. Chef Lugoli (3-0)**
+
+And now, what may be the penultimate set in the Top 8 stream: Hypernova vs. Chef Lugoli, with a chance at redemption against FreeFlow during Grand Finals on the line. 
+
+Hypernova in game one–Splat Zones at Crableg Capital–took an aggressive opening and earned a strong lead, only giving Chef Lugoli points toward their objective in bite-sized pieces. Ultimately, Chef Lugoli’s main downfall in the match was their inability to outpaint Hypernova. With a minute and 43 seconds left before the clock ran out, Hypernova reached zero on their objective and knocked out Chef Lugoli. 
+
+Into Rainmaker at Undertow Spillway, Hypernova would see Synapse switch to Dapple Dualies Nouveau and Fishy switch to the Zink Mini Splatling, but these major changes wouldn’t impact their dominating performance. Chef Lugoli capitalized on Hypernova’s right-side focus of the map to sneak to the right and take the first checkpoint. Hypernova would take their first checkpoint on the right, and by the halfway point on the clock, have their Rainmaker all the way at 18 points to go. Although it wasn’t a knockout, Hypernova would still win soundly, 82-44. 
+
+Clam Blitz at Museum d’Alfonsino was the combination for game three. It was a very slow match; the first points weren’t scored until halfway through the match timer, with Hypernova making their first–and only–push to take their score from 100 to 54\. The remainder of the game up until overtime was Hypernova playing hyper defense, not allowing any member of Chef Lugoli to advance past the spinner on their platform. Chef Lugoli had no problem collecting Power Clams; they just had no answer to Hypernova’s barricade. In overtime, the score was still 54-100 favoring Hypernova, but two jump-ins from Chef Lugoli brought that score to 54-60. Unfortunately, Chef Lugoli wouldn’t be able to close the distance after getting wiped out, and Hypernova won the match 46-40, and the set 3-0. 
+
+### **Grand Finals: FreeFlow vs. Hypernova (0-3)**
+
+Hypernova, seed \#1, having made quick work of their opponent in Loser’s Finals, was ready for the runback against FreeFlow, seed \#2 of the tournament, and prove that their earlier upset was a one-time feat. 
+
+Going into the first game, Splat Zones at Undertow Spillway, there weren’t any surprises in store from either teams about which weapons they picked. Hypernova took the first lead, holding the zone for about a minute before FreeFlow was able to take it long enough to grab a few points for themselves, then lose control. Since both zones at Undertow Spillway are small enough to neutralize by a Snipewriter 5H alone (which both teams had), Hypernova’s holds had to come by taking a forward position on FreeFlow’s side of the map and keeping their defense on lockdown. FreeFlow would be able to slip through on occasion; though during one of their zone possessions they did end up getting wiped out, giving Hypernova the chance to increase their lead even further, and ultimately win 87-38. 
+
+The last time Hypernova and FreeFlow played Clam Blitz at Um’ami Ruins, FreeFlow ended up with a knockout over Hypernova. This game was the opposite of that right from the get-go, as it took over a minute for either team to score at all. Hypernova would have three players go down, but someone was able to sneak past FreeFlow to put the first points on the board. FreeFlow would take the lead from Hypernova during their first push halfway through the game, and would also go down three players for the effort. One minute and 30 seconds remained, and Hypernova took the lead back. They would begin to slowly creep closer to an early win. Beating the clock timer and the basket timer, Captain Happy would score the final clam in the basket to deliver Hypernova a knockout victory with six seconds before they would have won anyway. 
+
+A major turning point for Grand Finals was decided with Rainmaker at Urchin Underpass. Interestingly, JJaeigh pulled out a Mint Decavitator of their own, for the first time in the entire Top 8 stream. This wouldn’t mean JJaeigh stopped doing their due diligence of causing chaos in Hypernova’s walls. Captain Happy would take the first checkpoint for Hypernova within the first 45 seconds, while in the background everyone else was fighting just beyond the pedestal. Hypernova would take this push further, but not far enough to stop FreeFlow from surpassing that lead about a minute and a half into the game. Just 30 seconds later, and Hypernova was back in the lead, and this time feeling comfortable enough with the score 28-47, they switched to playing defense. Hypernova successfully defended their lead and won the match, 72-53. They also won the Grand Finals, 3-0\! 
+
+…But that doesn’t mean they’ve won the tournament yet, either. Since Hypernova was coming from the Loser’s Bracket, that means the Splatoon 3 North American League was seeing its first bracket reset\! 
+
+### **Grand Finals Reset: FreeFlow vs. Hypernova (0-3)**
+
+The true final boss of any tournament: the bracket reset. As if winning in Grand Finals wasn’t physically, mentally, and emotionally draining enough as the underdog, there exists a sequel\! FreeFlow had to fight hard to win against Hypernova in the Winner’s Finals, and coming out of an 0-3 shutout in Grand Finals, they would have to be flashier, faster, and more locked-in than ever before. 
+
+If a bracket reset is the sequel to Grand Finals, then it’s only fitting that we would see Urchin Underpass back-to-back, this time with Splat Zones in the Urchin sequel. Again, JJaeigh switched to a weapon we hadn’t seen them play yet in this tournament, the Cometz Octobrush, in addition to Len. switching to the Blaster instead of S-BLAST ‘91. FreeFlow took a very solid lead in their opening push, down to just 20 points remaining, which would be their last push of the game. Would it be far enough to stop Hypernova? At about 3:20 on the match clock, Hypernova brought their points down to 50, with the scoreboard now 50-20. This score would remain for two minutes as teams went back and forth with zone possession, only burning through their penalties but never enough to start earning points again. Ten seconds left in the match, and Hypernova would take the lead and hold onto it–no overtime needed–for the first bracket reset win, 96-80. 
+
+Game two was played in Clam Blitz mode at Undertow Spillway. We did see some more changes from FreeFlow’s team, weapon-wise, but perhaps the most baffling was Adapt bringing in the Sloshing Machine. The inclusion of a weapon so rarely seen in top-level play today didn’t break Hypernova’s stride; their first push brought them from 100 to just 26 in the first minute of the game. FreeFlow would try to make a comeback from that, and made a significant dent in Hypernova’s lead, but the match was already over at exactly three minutes left: Hypernova had knocked out their opponent to win. 
+
+Game three, a common sight: Rainmaker at Humpback Pump Track, where anything can happen\! For this fight, everyone would go back to the weapon that they felt most comfortable with. Captain Happy would, again, take the first checkpoint for Hypernova, within the first 45 seconds. Again, it would take some time, but a triple taking down Hypernova’s players allowed FreeFlow to even the score and get their own first checkpoint. Things would remain at a stalemate for a while, but FreeFlow would get the lead with under two minutes remaining. Just 40 seconds to go, and Hypernova’s Rainmaker would be stopped with just one point left\! The delay didn’t stop them for long, and Hypernova would once again knock out FreeFlow, in the final match of the Grand Finals Reset, for a double shutout, 3-0. Winning six matches in a row against a team like FreeFlow was no easy feat. 
+
+<img width="1919" height="1079" alt="nal_p2_bracket" src="https://github.com/user-attachments/assets/e7729502-98be-4240-9bbf-e3d4bcb98075" />
+
+
+The Top 8 stream concluded with another rundown of what each event would have in store and when those events will take place. If this week’s action wasn’t hot enough, next week promises to raise the stakes, with scores now counting towards NA League Playoffs, attracting tougher opponents. Perhaps the most thrilling part of this entire event is the number of players, both new, current, and returning from retirement who plan on participating\! It will certainly shake up the mainstays in usual competitive play, and what an exciting thing to see livestreamed\! 
+
+Original Posting Date: September 30, 2025 
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add Stronghold Article, originally posted at https://www.splatoonstronghold.com/news/splatoon-3-north-american-league-event-2-preseason-week-2