### PR TITLE
Stronghold Article: SWS26 Recap: Playoffs

### DIFF
--- a/content/articles/sws26-recap-playoffs.md
+++ b/content/articles/sws26-recap-playoffs.md
@@ -1,0 +1,190 @@
+---
+title: "Recapping the Main Event of 2026: SWS26 Playoffs"
+date: 2026-08-25
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+#### *Fight for your right to crown your team 2026’s best in the world*
+
+<img width="1200" height="675" alt="SWS26-recap-Playoffs" src="https://github.com/user-attachments/assets/2f067a7f-4d99-42ab-8d39-7c95023e58b9" />
+
+On Friday, August 7, 2026, the Splat World Series 2026 tournament kicked off its weekend-long season finale. A collaboration between Inkling Performance Labs (IPL) and AREA CUP, the tournament showcased the best of the West and Japan in a sequel to 2025’s tournament of the same name. 
+
+The tournament was streamed live in two languages: English, streamed by [IPL](https://www.youtube.com/@iplsplatoon), and Japanese, steamed by [AREA CUP](https://www.youtube.com/@splatzonejp).
+
+Preceding this tournament were two Global Gauntlets (each featuring two qualifiers and one finals event). The West’s roster was determined by two qualifier events following the Global Gauntlets, where the top three teams from each qualifier earned their ticket to SWS26. The roster’s first two teams were invited based on their performance in the Global Gauntlets: 
+
+#### **Western Roster:** 
+- **PxG:** Grey, Soulja, Gos, Torareta  
+- **Milky Way:** bran, Jared, .q, Shadowind  
+- **FTWin:** \[K\]yo\!, Biscuit, Burstie, Leafi  
+- **Rip pig 9:** Xenith, y0shell, datkid, phoenix  
+- **Aeternus:** Ant, jaysorawk\!, Raiki, Punchy  
+- **Content Cat:** Atlas, Hawaiian, Chronos, GIMME, Pika  
+- **flower man:** Bonk, kairo, Reiyu, Eri  
+- **Ascension:** Sam, chivakola, Mirage, Coolace
+
+Japan’s teams were all selected by AREA CUP, both for the Global Gauntlets and for the Splat World Series 2026 Playoffs. While an Eastern Qualifier was intended to be held, it was canceled, and in its place, AREA CUP selected all of the teams: 
+
+#### **Japan’s Roster:** 
+- **Pacdora:** Momo, Norishio, Kasiwa, Rami, Erimomo  
+- **Vacuum World:** Hitokuchi Taberu, Samurai Kasato, Chiaki, Utan  
+- **King of Ham:** Todo, Inaten, Sofu, Tanaha  
+- **CutieNK:** tkf, Kae, Naenae, 9ray  
+- **Let’s Go Brother:** Wolbo, Grandroll, Neespa, Soppi  
+- **Paint Prime:** Livia, Rubytan, Kakao, Yocchan Ika  
+- **Rush:** Goyame, Streamer Sena, Suemaru, rifu  
+- **oddloop:** Natyu, Shito, Karada2Piece, Piece, K
+
+
+## **Day 1 Swiss:** 
+
+Day one started with a Play All 3 Round Robin Swiss bracket, which would determine each team’s seeding for day 2\. The event opened with a preshow hosted by Zach, Pat, and Kbot. IPL’s first commentator block for the West included Dark and Fufu, who switched out with Magic and Popgun for the second half of the day, and the spectator camera operator was Ely; on Japan’s side, the commentators were Hemi and Razzy, and Vital was running the spectator camera. 
+
+### **Rounds 1–6: Day 1 Features**
+
+Starting the event were the two most iconic maps that defined 2025’s Splat World Series: Eeltail Alley and Urchin Underpass. Both were maps heavily counterpicked due to its impact on E-liter players, either giving them an advantage over a wide area (Eeltail Alley) or forcing the player to switch to a different weapon due to an extreme disadvantage (Urchin Underpass). 
+
+**Results:**
+- Round 1: FTWin vs. King of Ham (1–2)  
+- Round 2: CutieNK vs. Milky Way (1–2)  
+- Round 3: Let’s Go Brother vs. Rush (2–1)  
+- Round 4: PxG vs. Paint Prime (1–2)  
+- Round 5: Rip Pig 9 vs. Let’s Go Brother (0–3)  
+- Round 6: FTWin vs. CutieNK (0–3)
+
+After day 1 concluded, no teams went 6–0; every single team lost at least one set. PxG, Milky Way, and Rip pig 9 were the only Western teams to take a set win from Japan, and PxG was the only Western team in the upper half of the seeding. 
+
+This event was unlike the Global Gauntlets, which were region vs. region—on day one, Western teams fought Western teams, and JP teams fought JP teams, leading to some interesting outcomes, such as Rip pig 9 taking a win from FTWin, Aeternus going 2–1 over Milky Way, and Vacuum World losing 0–3 to Paint Prime. 
+
+<img width="1148" height="706" alt="day1results" src="https://github.com/user-attachments/assets/5c0348ac-de39-48e4-bd55-037a2ccd0356" />
+
+*The results from day 1’s Swiss Round Robin stage.* 
+
+## **Day 2 Double-Elimination Bracket:** 
+
+Another preshow preceded the highly-anticipated action for day 2 of SWS26. Sasu, Cyren, and Magic were the preshow hosts, and would later return for the analysis desk at the halfway point break. 
+
+Pat and Popgun—the latter who was very enthusiastic about seeing Marlin Airport at least once during the event—were on IPL’s first commentator block, later replaced by Zach and Kbot. Hemi was back commentating for Japan, this time joined by Varucan. Ely and Vital were also again providing spectator camera operations for their respective regions. 
+
+Day two would begin with Best of 3 sets until Winner’s Semifinals, where it would turn into a Best of Five (with one exception being Loser’s Semifinals, which would also be a Bo3). 
+
+### **Winner’s Round 1: PxG vs. Milky Way**
+
+It is incredible to see an event of such a high caliber that a matchup like PxG vs. Milky Way, two of the West’s strongest teams, took place in Round 1\. The last time these teams met was SuperJump 7, back in December 2025, where their Grand Finals Reset came down to a game five that PxG won by not just *one* moment decided by mere frames, but *two*. As close as close can get—and now they had to meet in Round 1\!
+
+The first game saw PxG strike Urchin Underpass and Barnacle & Dime. Milky Way’s map strikes were Flounder Heights and Hammerhead Bridge. In true SWS fashion, the random map selection chose to start day two with the SWS25-iconic Eeltail Alley. The game, however, was less iconic, lasting a minute and a half and favoring PxG with their dominant 100-to-0 knockout. 
+
+After PxG struck Hagglefish Market and Um’ami Ruins, Milky Way counterpicked to Undertow Spillway, one of their favored maps. Halfway through the game, they took the lead from PxG, but in the last seconds, lost it, falling short by one point, 94–95, and were sent to the Loser’s Bracket while PxG advanced. 
+
+There were only two sets in Round 1 that were between regions; one West vs. West game (PxG vs. Milky Way) and one Japan vs. Japan game (King of Ham vs. oddloop). Both games ended 2–0, with PxG and King of Ham moving forward. 
+
+Making Splat World Series history, Rip pig 9 and Aeternus were the first Western teams to win a set against a Japanese team in the double-elimination tournament. Both teams won 2–1; Rip pig 9 over Paint Prime, and Aeternus over Rush. Content Cat, FTWin, flower man, and Ascension went 0–2 in their sets and joined Milky Way in the Loser’s Bracket.  
+
+### **Winner’s Round 2: Vacuum World vs. Rip pig 9**
+
+Rip pig 9, who was on a hot streak this event, was set to face Vacuum World, who only lost one set the previous day, coincidentally, to the same team that Rip pig 9 had just beaten: Paint Prime.
+
+The first map strikes were to Urchin Underpass, Humpback Pump Track, Crableg Capital, and Bluefin Depot. Game one went to Mincemeat Metalworks. Vacuum World was stopped from the 100-to-0 knockout at 2 ticks remaining, and Rip pig 9 did it again when their opponent was at 1 tick remaining. They fought to bring the game into overtime, but Vacuum World’s namesake, the Ink Vac, won them the game, 99–77.
+
+<img width="1100" height="618" alt="WR2_MMZip" src="https://github.com/user-attachments/assets/d1c42eea-6759-4766-8ca6-f2f65d55ddc9" />
+
+*Anticipating Vacuum World’s Ink Vac cheese, Rip pig 9 deploys a Zipcaster to counter it. The spectator camera captures a moment just frames before disaster struck, before changing views.*
+
+Vacuum World struck MakoMart and Manta Maria, leading to Rip pig 9’s selection of Robo ROM-en. Rip pig 9’s defense fell apart faster on the new map and they only gained 11 points in the game, unable to stop Vacuum World’s speedy knockout at 3:36. 
+
+With Winner’s Round 2 and Loser’s Round 1 over, four Western teams were eliminated from the Finals: FTWin, flower man, Content Cat, and Ascension. PxG, Aeternus, Milky Way, and Rip pig 9 were all in the Loser’s Bracket, but at least one Western team was guaranteed to make it the furthest any had been in SWS history, to Loser’s Round 3, as Aeternus vs. Milky Way was one of the Loser’s Bracket Round 2 sets. 
+
+### **Winner’s Semifinals: CutieNK vs. Pacdora**
+
+The event changed from a Bo3 to Bo5 starting with Winner’s Semifinals, but we’ve not seen the last of Bo3s yet—Loser’s Semifinals would be the final Bo3. 
+
+CutieNK struck Bluefin Depot and Robo ROM-en, and Pacdora banned Crableg Capital and Mahi-Mahi Resort. The map selection for game one was Hammerhead Bridge. Although they were stopped at 5 ticks, with plenty of time to spare, Pacdora ended the game with a knockout. 
+
+The next game was at Humpback Pump Track. Pacdora struck Hagglefish Market and Barnacle & Dime. The highest range CutieNK had was their REEF-LUX 450 Deco (60), while Pacdora’s shortest-ranged weapon was their Slosher (58). CutieNK was heavily out-ranged, but still pulled away with a knockout by the 3-minute mark, tying the set. 
+
+At this point in the tournament, both Rip pig 9 and PxG were eliminated; Rip pig 9 lost 2–1 to oddloop, who also took out FTWin, and PxG lost 2–1 to Rush, who had just come from defeating Ascension. Aeternus and Milky Way were left, fighting to determine which between the two advanced to the next round. 
+
+Inkblot Art Academy was the stage for game three, after CutieNK’s map strikes removed Museum d’Alfonsino and Eeltail Alley from the pool. In a very quick game barely lasting a minute and 20 seconds, Pacdora ended up with another knockout. 
+
+<img width="1100" height="618" alt="WSF_IAABooyah" src="https://github.com/user-attachments/assets/b5190bf1-2e34-42ff-be0a-8a3bbba368f5" />
+
+*Pacdora teammates Norishio and Rami share a Booyah\! to celebrate their 100-to-0 knockout.*
+
+Pacdora’s final map strikes were Sturgeon Shipyard and Flounder Heights; CutieNK’s final map selection was MakoMart. CutieNK had the lead after the first minute ended, but Pacdora swept in and took it for themselves, once more taking another knockout win with minutes to spare, advancing to Winner’s Finals.
+
+Meanwhile, Milky Way had won their set 2–0 against Aeternus. They would also advance, to Loser’s Round 3, where Rush, the same team who had eliminated PxG, awaited them. A greater challenge awaited Milky Way in this opponent, as Rush was also the first Japanese team they would be facing in the tournament after only fighting Western teams up to this point.
+
+### **Winner’s Finals: Vacuum World vs. Pacdora**
+
+Vacuum World, seed \#2 for day two, met day one’s seed \#1 Pacdora in Winner’s Finals. 
+
+Sturgeon Shipyard was the first map, after Bluefin Depot, Robo ROM-en, Urchin Underpass, and Lemuria Hub were struck. While Pacdora put up a good fight despite being at a numbers disadvantage consistently, they lost the game by a knockout in the last 20 seconds. 
+
+By now, the results of Milky Way and Rush’s set were available: Milky Way, the last Western team in the SWS26 Finals, had lost 0–2 and were eliminated from the tournament. From this point forward, the rest of the tournament would be between the AREA CUP invitees. 
+
+Vacuum World struck Undertow Spillway and Brinewater Springs. Pacdora selected Inkblot Art Academy—confident in their choice, after two minutes, they took the lead from Vacuum World. On their way to the knockout, Pacdora wiped out their opponent, tying the set 1–1. 
+
+Pacdora opted to strike Barnacle & Dime and Hagglefish Market. The game went to Flounder Heights. Taking Vacuum World down three players, Pacdora finally got points to their name. They ended up floundering a bit themselves, ultimately getting wiped out seconds before Vacuum World knocked out and took the win. 
+
+Game four—match point for Vacuum World, who struck out Wahoo World and Crableg Capital. Pacdora selected Mahi-Mahi Resort, and would replay the events of game two, where they knocked out the win on their counterpick before the clock’s halfway point. 
+
+Pacdora’s map strikes were Eeltail Alley and Hammerhead Bridge. Pacdora brought the MakoMart zone down to 8 ticks remaining before a minute and a half passed. As the one minute mark neared, Vacuum World went down three players and their push was stopped at 9 ticks. With the score neck-and-neck, overtime began. Vacuum World broke through their penalty to take the lead, 93–92, and advanced to Grand Finals. 
+
+<img width="1200" height="675" alt="WF_MakoMartClose" src="https://github.com/user-attachments/assets/ae3b345f-34be-420d-af39-633161007163" />
+
+*As the clock nears one minute remaining, Pacdora stops Vacuum World one point from tying the score. In the end, Vacuum World would end up with the victory after overtime.* 
+
+### **Loser’s Semifinals: King of Ham vs. Rush**
+
+As the tournament shifted from the Winner’s Bracket to the Loser’s Bracket, the analysis desk featuring Sasu, Cyren, and Magic took over. Meanwhile, Zach and Kbot swapped in for Pat and Popgun to handle the commentary for the rest of the tournament. 
+
+King of Ham vs. Rush was the final Bo3 set of the Splat World Series. The first game, at Mahi-Mahi Resort, was a close fight, ending 96–92 for Rush. Rush then knocked out at Brinewater Springs, taking the set 2–0 and advancing to Loser’s Finals. 
+
+### **Loser’s Finals: Pacdora vs. Rush**
+
+The two opening games of Pacdora and Rush’s set featured fierce fights, but ultimately went to Rush. The first win was at Robo ROM-en, where Rush won 84–75. Next, at Mahi-Mahi Resort, Rush won by a knockout, but only with about 30 seconds remaining, and Pacdora had only been one point away from tying before being knocked out. 
+
+Pacdora had their reversal at Marlin Airport—Popgun, after spending every set previously wishing for the map to appear, would have been elated to commentate this game if he hadn’t swapped out already. Pacdora won the game in less than three minutes, keeping the set alive, although Rush needed only one more win to advance. 
+
+The set went to Flounder Heights. The game was almost entirely in Rush’s hands, evidenced by the team’s Splat Roller getting a quad before the first minute was up. Rush knocked out little more than two minutes into the game, bringing their tournament run back to the Winner’s Bracket for the first time since the very first set that sent them into the Loser’s Bracket. 
+
+## **Grand Finals: Vacuum World vs. Rush**
+
+Grand Finals on day 2 was not Vacuum World’s first time facing Rush—on the previous day, they met in Round 4, where Vacuum World won 2–1. Additionally, Rush had made their way to Grand Finals through the Loser’s Bracket after being sent there by Aeternus in Round 1\. The odds weren’t looking in Rush’s favor on paper, but on the battlefield, they only seemed to grow stronger and stronger. 
+
+After Vacuum World struck MakoMart and Inkblot Art Academy, and Rush struck Lemuria Hub and Crableg Capital, the game went to Hammerhead Bridge. Both teams mirrored a .96 Gal, Tri-Slosher Nouveau, and E-Liter 4K. 
+
+Rush started the game on their back foot, down three players and Vacuum World taking their zone to 31 ticks remaining as an opening push. However, they were quick to take the lead afterward, stopping with only 4 ticks to win. Vacuum World was able to bring their score close, but faltered in overtime; the first victory went to Rush, 96–94. 
+
+The second game went to Hagglefish Market after Rush’s chosen map strikes were Barnacle & Dime and Bluefin Depot. While not a 100-to-0 knockout, Vacuum World won quite decisively, leaving over two minutes to spare after their knockout. 
+
+Game three had Vacuum World striking Undertow Spillway and Scorch Gorge; Rush counterpicked to Sturgeon Shipyard. Again, Rush was at the disadvantage early in the game, but by the midpoint, they were in control and in the lead. At 1:45 on the clock, Rush had knocked out—one more win, and they would force a set reset…
+
+…Which is what happened after Rush knocked out again at Mahi-Mahi Resort during game four, where they made sure to hammer in their point by wiping Vacuum World out shortly before their victory.  
+
+<img width="1100" height="618" alt="GF_VictoryRush" src="https://github.com/user-attachments/assets/51c20622-8b1d-4aa6-ab54-ecc2affcb5d6" />
+
+*The players of Rush, having forced a Grand Finals Reset: rifu, Streamer Sena, Goyame, Suemaru.*
+
+## **Grand Finals Reset: Vacuum World vs. Rush**
+
+Vacuum World decided to strike MakoMart and Undertow Spillway; Rush stuck with their same map strikes and blocked Crableg Capital and Lemuria Hub. Game one went to Mahi-Mahi Resort, where it was Rush’s third win in a row, by knockout, no less. 
+
+The next game went to Wahoo World after Rush’s next strikes took out Barnacle & Dime and Bluefin Depot. In the less-than-90-seconds face-off, Vacuum World won by a knockout, only allowing their opponent 5 points early in the game.
+
+At Sturgeon Shipyard for game three again, after Vacuum World banned Inkblot Art Academy and Humpback Pump Track, just as quickly, Rush rebounded with an unmistakable win of their own. This time, they denied Vacuum World any points, earning themselves the 100-to-0 knockout and making it to match point once more. 
+
+Hagglefish Market was Vacuum World’s selection for game four after Rush struck Museum d’Alfonsino and Eeltail Alley. The zone flipped a few times in the first minute, ending with Vacuum World wiped out and Rush in control. Just 30 seconds later, Vacuum World was wiped out again, leading to Rush’s final knockout of the event, securing the victory for themselves. 
+
+After fighting their way up through the Loser’s Bracket and through two Grand Finals sets against Vacuum World, who was the highest-seeded team for day 2 and highly-anticipated to win, Rush joined The Invincible Fleet Reimaru as the second-ever Splat World Series champion\! 
+
+The final brackets for both days of Splat World Series 2026 can be found on Sendou.ink: [https://sendou.ink/to/3376/info](https://sendou.ink/to/3376/info). 
+
+Before the Grand Finals set aired, the stream also showcased the credits video, highlighting the members of the tournament organization and production crew who dedicated hours of hard work into making the event as much of a spectacle as it was. You can watch the credits video on IPL’s YouTube channel, here: [https://www.youtube.com/watch?v=9tpGfhBzVTs](https://www.youtube.com/watch?v=9tpGfhBzVTs). 
+
+Original Posting Date: August 25, 2026 at [Splatoon Stronghold](https://www.splatoonstronghold.com/news/sws26-recap-playoffs).
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add article from Splatoon Stronghold: "Recapping the Main Event of 2026: SWS26 Playoffs"; repost of https://www.splatoonstronghold.com/news/sws26-recap-playoffs.