### PR TITLE
Stronghold Article: SendouQ Season 12 Finale Recap

### DIFF
--- a/content/articles/sendouq-season12-finale-recap.md
+++ b/content/articles/sendouq-season12-finale-recap.md
@@ -1,0 +1,78 @@
+---
+title: "SendouQ Season 12 Finale Recap"
+date: 2026-09-03
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+#### *SendouQ’s season finale continues to evolve and test qualifying teams’ mettle*
+
+<img width="1200" height="630" alt="SQS12_Recap" src="https://github.com/user-attachments/assets/096f7504-0e33-449d-995f-ce40c2cab74e" />
+
+On Saturday, August 29, 2026, SendouQ’s summertime season wrapped up with its largest and most worldwide tournament yet: the SendouQ Season 12 Finale. Fourteen teams met in seven rounds of Round Robin groups, which determined the seeding for the Top Cut Single-Elimination bracket, made up of the four best teams. The event was Splat Zones-only, with a $500 USD prize. 
+
+Outside of having the most teams yet in the Finale, it was also the most global event, featuring two teams from Japan: デメニギーズ (pronounced demene-gee-szu) and Fire and Ice. デメニギーズ was the team to watch, having two players from first and second place at the Splat World Series 2026 Playoffs: Chiaki (Vacuum World) and Goyame (Rush). 
+
+DRF and Neato were clocked in for the first commentary block, which covered the first five rounds of the Round Robin stage. Starting with Round 6, Fufu and Nox replaced DRF and Neato, closing out the Group stage and Top Cut bracket. 
+
+## **Group Stage**
+
+The Group Stage was a Best of Five Round Robin, split into Group A and Group B. This stage determined the top four teams (top two per Group) who would advance to the Top Cut bracket later. 
+
+Seven sets were broadcast live on IPL’s Twitch and YouTube channels: 
+
+**Group B, Round 1:** Whirlwind vs. Moonlight (2–3)  
+**Group A, Round 2:** Faded Dream vs. Takedown (1–3)  
+**Group A, Round 3:** Fire and Ice vs. Frosted Flakes (3–2)
+
+<img width="1200" height="674" alt="GA3_MMWipe" src="https://github.com/user-attachments/assets/f0945409-b4d9-4b40-9111-3ffa83d11ec5" />
+
+*During game four at MakoMart, Frosted Flakes wipes out Fire and Ice with one player left standing, which secures their victory, 95–41.* 
+
+**Group A, Round 4:** Poltergeist vs. Takedown (2–3)  
+**Group B, Round 5:** PXTD vs. デメニギーズ  (1–3)  
+**Group A, Round 6:** Frosted Flakes vs. Grougrou (0–3)  
+**Group B, Round 7:** Moonlight vs. Aeternus (1–3)
+
+For those who are sensitive to the Splattercolor Screen’s audio and visual disruption, take caution watching the Group B, Round 7 set between Moonlight and Aeternus, as the Splattercolor Screen was used and its effects were on screen. 
+
+<img width="1200" height="483" alt="GroupStageResults" src="https://github.com/user-attachments/assets/975f80ff-df59-4d80-8649-a058d97eb9b4" />
+
+## **Top Cut**
+
+Top Cut was a two-round Single-Elimination bracket. Only the top two teams from each Group from the earlier stage advanced, starting right at the Semifinals. Counterpicks were now active, and Finals would change from a Bo5 to a Bo7. 
+
+### **Semifinals: デメニギーズ vs. Grougrou (3–0)**
+
+The commentators were given a choice of picking between Fire and Ice vs. PXTD or デメニギーズ vs. Grougrou, and they chose the latter. Both were powerhouse teams, seeds \#2 and \#1. デメニギーズ had two SWS26 Playoffs podium-placing players (Chiaki and Goyame), and Grougrou was PxG (Grey, Noah, Yeti, mino). 
+
+The first game was at Um’ami Ruins. With a wipeout on Grougrou 30 seconds in, デメニギーズ secured the zones for the first time, and only time. One minute later, デメニギーズ already had themselves the knockout victory. 
+
+Flounder Heights was the counterpick for game two. Grougrou claimed the zones first, though デメニギーズ took the lead from them quickly. Grougrou struggled to keep players on the field, and ultimately lost by another デメニギーズ knockout. 
+
+Grougrou’s last counterpick was MakoMart. Again, the first points of the game were theirs, but they were overtaken by デメニギーズ. They were able to stop デメニギーズ at 27 after taking them down three players, but Grougrou was wiped out. The wipeout led to one final knockout from デメニギーズ, sending them to Finals while Grougrou’s run was cut short at 3rd place. 
+
+<img width="1200" height="674" alt="TC_SF_Winner" src="https://github.com/user-attachments/assets/f2352896-70d3-48c2-94a1-260251e233e7" />
+
+*デメニギーズ, repping their team captain Chiaki’s signature outfit: Ink-Tinted Goggles, Octo Jumper Away, Snow Delta Straps. Steal their look\!*
+
+### **Finals: Fire and Ice vs. デメニギーズ (0–4)**
+
+After Fire and Ice reverse-swept PXTD, they advanced to meet the other Japanese team of the tournament, デメニギーズ. Regardless of who won, they would be making history as the first JP team to win a SendouQ Season Finale, accomplishing what Flow Dragons (a 3/4 JP team) from the Season 10 Finale could not. 
+
+Finals kicked off at Robo ROM-en, where デメニギーズ took the zone first. Fire and Ice stopped them at 22 with help from their Super Chumps; they took the lead before long and held it until デメニギーズ wiped them out, winning by a knockout yet again. 
+
+The next game went to Undertow Spillway. Both teams went down two players; デメニギーズ came out of the scuffle with the zones in their control. Fire and Ice was wiped out twice in the second minute of the game, which became the last as デメニギーズ once again knocked out early to win. 
+
+Game three went to Scorch Gorge—Fire and Ice capped the large zone first, nearly 45 seconds into the game. Fire and Ice held onto the zone for a bit, but they were wiped out, stopped at 67 ticks remaining. Only 30 seconds later, デメニギーズ had the lead. They began to lock Fire and Ice away from the zone, and earned another knockout win.
+
+Fire and Ice’s last counterpick was Um’ami Ruins. They had the lead and made it all the way to 46 ticks remaining in just two minutes. At the halfway point on the clock, Fire and Ice was wiped out; デメニギーズ took the zone and the lead, and as the clock read 2:15, claimed the final victory of the tournament in a knockout. 
+
+<img width="485" height="292" alt="TopCutBracket" src="https://github.com/user-attachments/assets/a3b9f53e-9004-407c-a775-f2c2c0d0d811" />
+
+In a post-Splat World Series scene, more and more traditionally-Western tournaments are starting to see Japanese players partake. The skill gap between East and West may still feel large, but greater mingling between the two will bring the regions closer in more than one way.  
+
+Original Posting Date: September 3, 2026 at [Splatoon Stronghold](https://www.splatoonstronghold.com/news/sendouq-season-12-finale).
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add article from Splatoon Stronghold, "SendouQ Season 12 Finale Recap", repost of https://www.splatoonstronghold.com/news/sendouq-season-12-finale.